### PR TITLE
Please load Json gem first in JRuby

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -1,7 +1,8 @@
 module MultiJson
   class DecodeError < StandardError; end
   module_function
-
+  
+  
   @engine = nil
 
   # Get the current engine class.
@@ -11,12 +12,20 @@ module MultiJson
     @engine
   end
 
+  
+  
   REQUIREMENT_MAP = [
     ["yajl", :yajl],
     ["json", :json_gem],
     ["json/pure", :json_pure]
   ]
-
+  
+  # Swap ordering if it's JRuby
+  if defined?(JRUBY_VERSION)
+    REQUIREMENT_MAP[0], REQUIREMENT_MAP[1] = REQUIREMENT_MAP[1], REQUIREMENT_MAP[0]
+  end
+  
+  
   # The default engine based on what you currently
   # have loaded and installed. First checks to see
   # if any engines are already loaded, then checks


### PR DESCRIPTION
In JRuby loading Yajl first will create memory leaks in a lot of cases...

I have an app that enqueues jobs into Resque and since it uses MultiJson as it's Json gem it was defaulting to Yajl.  Of course at first I figured Resque might have memory leaks but it was really Yajl... 

Please accept this pull request for all of the JRubyists out there;)

thx!

-Matt
