### PR TITLE
Remove git dependency from gemspec

### DIFF
--- a/multi_json.gemspec
+++ b/multi_json.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.required_rubygems_version = Gem::Requirement.new(">= 1.3.6")
   gem.summary = %q{A gem to provide swappable JSON backends.}
-  gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
+  gem.test_files = Dir['spec/**/*']
   gem.version = MultiJson::VERSION
 end


### PR DESCRIPTION
Some environments may not have git installed, but the user still may need to build a gem from a gemspec (such as ours at work). It's probably in general a good idea to remove shell script dependencies as much as possible from gemspecs anyways, making the build more easily repeatable across different environments. Rails and other projects just use DIR to build the filelist in the spec, which I have added to multi_json.
