### PR TITLE
Fix for #21: MultiJson::DecodeError should contain string attempting to be parsed

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -1,5 +1,14 @@
 module MultiJson
-  class DecodeError < StandardError; end
+  class DecodeError < StandardError
+    attr_reader :data
+    def initialize(message, backtrace, data)
+      super(message)
+      self.set_backtrace(backtrace)
+      self.data= data
+    end
+  private
+    attr_writer :data
+  end
   module_function
 
   @engine = nil
@@ -64,7 +73,7 @@ module MultiJson
   def decode(string, options = {})
     engine.decode(string, options)
   rescue engine::ParseError => exception
-    raise DecodeError, exception.message, exception.backtrace
+    raise DecodeError.new(exception.message, exception.backtrace, string)
   end
 
   # Encodes a Ruby object as JSON.

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -100,6 +100,15 @@ describe "MultiJson" do
           end.should raise_error(MultiJson::DecodeError)
         end
 
+        it 'raises MultiJson::DecodeError with data on invalid JSON' do
+          data = '{crapper}'
+          begin
+            MultiJson.decode(data)
+          rescue MultiJson::DecodeError => de
+            de.data.should == data
+          end
+        end
+
         it 'stringifys symbol keys when encoding' do
           encoded_json = MultiJson.encode(:a => 1, :b => {:c => 2})
           MultiJson.decode(encoded_json).should == { "a" => 1, "b" => { "c" => 2 } }


### PR DESCRIPTION
Sometimes indirect clients of MultiJson have no easy way to determine the data attempting to be parsed into JSON, therefore a data attribute is added to MultiJson::DecodeError class and attribute is set when raising the exception.
