### PR TITLE
Add warning when using ok_json

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -25,6 +25,8 @@ module MultiJson
     ["json/pure", :json_pure]
   ]
 
+  DEFAULT_ENGINE_WARNING = 'Warning: multi_json is using default ok_json engine. Suggested action: require and load an appropriate JSON library.'
+
   # The default engine based on what you currently
   # have loaded and installed. First checks to see
   # if any engines are already loaded, then checks
@@ -42,6 +44,7 @@ module MultiJson
       end
     end
 
+    Kernel.warn DEFAULT_ENGINE_WARNING
     :ok_json
   end
 

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -26,6 +26,11 @@ describe "MultiJson" do
       it 'defaults to ok_json if no other json implementions are available' do
         MultiJson.default_engine.should == :ok_json
       end
+
+      it 'prints a warning' do
+        Kernel.should_receive(:warn).with(/warning/i)
+        MultiJson.default_engine
+      end
     end
 
     it 'defaults to the best available gem' do


### PR DESCRIPTION
This pull does the following:
- ensures that `::Yajl` and `::JSON` are undefined for the duration of the `ok_json` engine tests, even if they are run _after_ others
- prints a warning if multi_json is using ok_json
- closes #23
