### PR TITLE
please namespace okjson to avoid conflicts with other libraries

### DIFF
--- a/lib/multi_json/engines/ok_json.rb
+++ b/lib/multi_json/engines/ok_json.rb
@@ -1,18 +1,18 @@
-require "multi_json/vendor/ok_json" unless defined?(::OkJson)
+require "multi_json/vendor/ok_json" unless defined?(::MultiJson::OkJson)
 
 module MultiJson
   module Engines
     class OkJson
-      ParseError = ::OkJson::Error
+      ParseError = ::MultiJson::OkJson::Error
 
       def self.decode(string, options = {}) #:nodoc:
         string = string.read if string.respond_to?(:read)
-        result = ::OkJson.decode(string)
+        result = ::MultiJson::OkJson.decode(string)
         options[:symbolize_keys] ? symbolize_keys(result) : result
       end
 
       def self.encode(object) #:nodoc:
-        ::OkJson.valenc(stringify_keys(object))
+        ::MultiJson::OkJson.valenc(stringify_keys(object))
       end
 
       def self.symbolize_keys(object) #:nodoc:

--- a/lib/multi_json/vendor/ok_json.rb
+++ b/lib/multi_json/vendor/ok_json.rb
@@ -25,7 +25,7 @@ require 'stringio'
 # Some parts adapted from
 # http://golang.org/src/pkg/json/decode.go and
 # http://golang.org/src/pkg/utf8/utf8.go
-module OkJson
+module MultiJson::OkJson
   extend self
 
 


### PR DESCRIPTION
Hi, I've had reports of people getting errors when using two
libraries that both bundle okjson. These errors are usually
innocuous -- it's just things like constants being defined
twice -- but still it'd be nice to avoid them. (And it's more
serious if someone has patched their bundled copy of
okjson to modify its behavior.)

The solution we came up with was to request that libraries
bundling okjson rename the module to avoid conflicts. So
here's a patch to do that.
