### PR TITLE
Also need to deprecate engine= first.

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -47,6 +47,12 @@ module MultiJson
     self.adapter
   end
 
+  # TODO: Remove for 2.0 release (but no sooner)
+  def engine=(new_engine)
+    Kernel.warn "#{Kernel.caller.first}: [DEPRECATION] MultiJson.engine= is deprecated and will be removed in the next major version. Use MultiJson.use instead."
+    self.use(new_engine)
+  end
+  
   # Get the current adapter class.
   def adapter
     return @adapter if @adapter


### PR DESCRIPTION
Just found that Rails test started failing today after new release. I am not sure that how we can go with this. But we need to deprecate engine= also.

https://github.com/rails/rails/blob/master/activesupport/lib/active_support/json/decoding.rb#L26
