### PR TITLE
Fix rescue-clause for MagLev

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -90,9 +90,11 @@ module MultiJson
     # <tt>:adapter</tt> :: If set, the selected engine will be used just for the call.
     def load(string, options={})
       adapter = current_adapter(options)
-      adapter.load(string, options)
-    rescue adapter::ParseError => exception
-      raise DecodeError.new(exception.message, exception.backtrace, string)
+      begin
+        adapter.load(string, options)
+      rescue adapter::ParseError => exception
+        raise DecodeError.new(exception.message, exception.backtrace, string)
+      end
     end
     # :nodoc:
     alias :decode :load


### PR DESCRIPTION
MagLev evaluates rescue clauses eagerly. This fix allows multi_json to run on MagLev
