### PR TITLE
Remove erroneous check for string version of options key for Oj adapter.

### DIFF
--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -9,12 +9,12 @@ module MultiJson
       ::Oj.default_options = {:mode => :compat}
 
       def self.load(string, options={}) #:nodoc:
-        options.merge!(:symbol_keys => options[:symbolize_keys] || options['symbolize_keys'])
+        options.merge!(:symbol_keys => options[:symbolize_keys])
         ::Oj.load(string, options)
       end
 
       def self.dump(object, options={}) #:nodoc:
-        options.merge!(:indent => 2) if options[:pretty] || options['pretty']
+        options.merge!(:indent => 2) if options[:pretty]
         ::Oj.dump(object, options)
       end
     end


### PR DESCRIPTION
Removing unnecessary and erroneous check for string version of options key, which resulted the symbol version being masked when value is false.

E.g. 

```
MultiJson.load('{"a"=>1}', :symbolize_keys => false)  
```
