### PR TITLE
Fix Oj ParseError mapping for Oj 1.4.0

### DIFF
--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -4,7 +4,11 @@ module MultiJson
   module Adapters
     # Use the Oj library to dump/load.
     class Oj
-      ParseError = SyntaxError
+      ParseError = if defined?(::Oj::ParseError)
+        ::Oj::ParseError
+      else
+        SyntaxError
+      end
 
       ::Oj.default_options = {:mode => :compat}
 


### PR DESCRIPTION
Map Oj adapter ParseError to custom error class when it is defined. This was changed in Oj 1.4.0.
