### PR TITLE
Allow to load and dump JSON fragments

### DIFF
--- a/lib/multi_json/adapters/json_common.rb
+++ b/lib/multi_json/adapters/json_common.rb
@@ -4,7 +4,7 @@ module MultiJson
 
       def load(string, options={})
         string = string.read if string.respond_to?(:read)
-        ::JSON.parse(string, :symbolize_names => options[:symbolize_keys])
+        ::JSON.parse(string, :symbolize_names => options[:symbolize_keys], :quirks_mode => true)
       end
 
       def dump(object, options={})

--- a/lib/multi_json/adapters/ok_json.rb
+++ b/lib/multi_json/adapters/ok_json.rb
@@ -7,7 +7,7 @@ module MultiJson
 
       def self.load(string, options={}) #:nodoc:
         string = string.read if string.respond_to?(:read)
-        result = ::MultiJson::OkJson.decode(string)
+        result = ::MultiJson::OkJson.decode("[#{string}]").first
         options[:symbolize_keys] ? symbolize_keys(result) : result
       end
 

--- a/spec/adapter_shared_example.rb
+++ b/spec/adapter_shared_example.rb
@@ -61,6 +61,11 @@ shared_examples_for "an adapter" do |adapter|
     it 'dumps custom objects which implement as_json' do
       expect(MultiJson.dump(TimeWithZone.new)).to eq "\"2005-02-01T15:15:10Z\""
     end
+
+    it 'allow to dump JSON values' do
+      expect(MultiJson.dump(42)).to eq '42'
+    end
+
   end
 
   describe '.load' do
@@ -109,5 +114,10 @@ shared_examples_for "an adapter" do |adapter|
         expect(MultiJson.load(example, :symbolize_keys => true)).to eq expected
       end
     end
+
+    it 'allow to load JSON values' do
+      expect(MultiJson.load('42')).to eq 42
+    end
+
   end
 end


### PR DESCRIPTION
Hi,

This change allow to load JSON values.
It fix #54, #55, #17 and #13

I know that [json.org](json.org) specify that only arrays and objects are valid JSON documents.
But who said MultiJson should only parse document and not values ?

Ruby libraries:

``` ruby
>> Yajl.load('null')
=> nil
>> Oj.load('null')
=> nil
>> JSON.parse('null', quirks_mode: true) # Both json and json/pure
=> nill
```

Javascript

``` javascript
>> JSON.parse('null')
=> null
```

For both Chrome native object and JSON2.js by Douglas Crokford author of the JSON spec

Php

``` php
php> =json_decode('1') // phpsh to do display null values ...
1
```

Python

``` python
>>> json.loads('1') # Same for Python ...
1
```

Regards.
