### PR TITLE
Guard against Oj Fixnum TypeError

### DIFF
--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -12,6 +12,20 @@ module MultiJson
 
       ::Oj.default_options = {:mode => :compat}
 
+      def self.stringify_keys(object)
+        case object
+        when Hash
+          object.inject({}) do |memo, (k,v)|
+            memo[k.to_s] = stringify_keys(v)
+            memo
+          end
+        when Array
+          object.map(&method(:stringify_keys))
+        else
+          object
+        end
+      end
+
       def self.load(string, options={}) #:nodoc:
         options.merge!(:symbol_keys => options[:symbolize_keys])
         ::Oj.load(string, options)
@@ -19,7 +33,7 @@ module MultiJson
 
       def self.dump(object, options={}) #:nodoc:
         options.merge!(:indent => 2) if options[:pretty]
-        ::Oj.dump(object, options)
+        ::Oj.dump(stringify_keys(object), options)
       end
     end
   end

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -78,6 +78,16 @@ describe 'MultiJson' do
     end
   end
 
+  it "stringifies keys before coding with Oj adapter" do
+    MultiJson.use :oj
+    Oj.should_receive(:dump).with({"100" => "foo", "200" => "bar"}, {})
+    MultiJson.dump({100 => "foo", 200 => "bar"})
+    Oj.should_receive(:dump).with([{"100" => "foo"}, {"200" => "bar"}], {})
+    MultiJson.dump([{100 => "foo"}, {200 => "bar"}])
+    Oj.should_receive(:dump).with({"1" => {"2" => {"3" => "foobar"}}}, {})
+    MultiJson.dump({1 => {2 => {3 => "foobar"}}})
+  end
+
   %w(json_gem json_pure nsjsonserialization oj ok_json yajl).each do |adapter|
     next if !macruby? && adapter == 'nsjsonserialization'
     next if jruby? && (adapter == 'oj' || adapter == 'yajl')


### PR DESCRIPTION
We've decided to switch to Oj recently and it didn't went very well. Turned out that some of the json we were feeding to `MultiJson.dump` contained hashes with Fixnum keys in it.

Other adapters are happily chewing it by simply converting Fixnum keys into strings without any problems. Oj errors on this:

```
TypeError: In :compat mode all Hash keys must be Strings or Symbols, not Fixnum.
```

This change stringifies the object before passing it to `Oj.dump` making the whole thing consistent with other adapters.
