### PR TITLE
MultiJson.with_adapter

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -123,6 +123,7 @@ module MultiJson
     ensure
       self.adapter = old_adapter
     end
+    alias :with_engine :with_adapter
 
   end
 

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -83,6 +83,9 @@ describe 'MultiJson' do
     MultiJson.with_adapter(:json_pure) do
       expect(MultiJson.adapter.name).to eq 'MultiJson::Adapters::JsonPure'
     end
+    MultiJson.with_engine(:yajl) do
+      expect(MultiJson.adapter.name).to eq 'MultiJson::Adapters::Yajl'
+    end
     expect(MultiJson.adapter.name).to eq 'MultiJson::Adapters::OkJson'
   end
 


### PR DESCRIPTION
``` ruby

MultiJson.use :oj

MultiJson.with_adapter(:yajl) do
  # using yajl here for some reason
  MultiJson.load(json_string) # yajl kicks in
end

# still using oj here
MultiJson.dump(some_hash)

```
