### PR TITLE
Encoding error when using json_pure adapter

### DIFF
--- a/spec/adapter_shared_example.rb
+++ b/spec/adapter_shared_example.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 shared_examples_for "an adapter" do |adapter|
 
   before do
@@ -88,6 +90,9 @@ shared_examples_for "an adapter" do |adapter|
       expect(MultiJson.dump(42)).to eq '42'
     end
 
+    it 'allow to dump JSON with UTF-8 characters' do
+      expect(MultiJson.dump({'color' => 'żółć'})).to eq('{"color":"żółć"}')
+    end
   end
 
   describe '.load' do
@@ -141,5 +146,8 @@ shared_examples_for "an adapter" do |adapter|
       expect(MultiJson.load('42')).to eq 42
     end
 
+    it 'allow to load JSON with UTF-8 characters' do
+      expect(MultiJson.load('{"color":"żółć"}')).to eq({'color' => 'żółć'})
+    end
   end
 end


### PR DESCRIPTION
Error appears from version 1.4.0 (it was working fine on 1.3.7).

``` ruby
MultiJson.adapter = :json_pure
MultiJson.decode("{\"color\":\"żółć\"}")
MultiJson::DecodeError Exception: Caught Encoding::CompatibilityError at '{"color":"żółć"}': incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)
```

It works after forcing encoding to ASCII-8BIT:

``` ruby
MultiJson.adapter = :json_pure
MultiJson.decode("{\"color\":\"żółć\"}".force_encoding("ASCII-8BIT"))
 => {"color"=>"żółć"}
```
