### PR TITLE
Fixed failing ActiveSupport specs

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -3,7 +3,7 @@ module MultiJson
 
   class LoadError < StandardError
     attr_reader :data
-    def initialize(message="", backtrace=[], data="")
+    def initialize(message='', backtrace=[], data='')
       super(message)
       self.set_backtrace(backtrace)
       @data = data
@@ -16,11 +16,11 @@ module MultiJson
   attr_accessor :default_options
 
   REQUIREMENT_MAP = [
-    ["oj", :oj],
-    ["yajl", :yajl],
-    ["json", :json_gem],
-    ["gson", :gson],
-    ["json/pure", :json_pure]
+    ['oj',        :oj],
+    ['yajl',      :yajl],
+    ['json',      :json_gem],
+    ['gson',      :gson],
+    ['json/pure', :json_pure]
   ]
 
   # The default adapter based on what you currently
@@ -42,7 +42,7 @@ module MultiJson
       end
     end
 
-    Kernel.warn "[WARNING] MultiJson is using the default adapter (ok_json). We recommend loading a different JSON library to improve performance."
+    Kernel.warn '[WARNING] MultiJson is using the default adapter (ok_json). We recommend loading a different JSON library to improve performance.'
     :ok_json
   end
   # :nodoc:

--- a/spec/adapter_shared_example.rb
+++ b/spec/adapter_shared_example.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-shared_examples_for "an adapter" do |adapter|
+shared_examples_for 'an adapter' do |adapter|
 
   before do
     begin
@@ -14,7 +14,7 @@ shared_examples_for "an adapter" do |adapter|
     it 'writes decodable JSON' do
       [
         {'abc' => 'def'},
-        [1, 2, 3, "4", true, false, nil]
+        [1, 2, 3, '4', true, false, nil]
       ].each do |example|
         expect(MultiJson.load(MultiJson.dump(example))).to eq example
       end
@@ -64,8 +64,8 @@ shared_examples_for "an adapter" do |adapter|
     end
 
     it 'dumps rootless JSON' do
-      expect(MultiJson.dump("random rootless string")).to eq "\"random rootless string\""
-      expect(MultiJson.dump(123)).to eq "123"
+      expect(MultiJson.dump('random rootless string')).to eq '"random rootless string"'
+      expect(MultiJson.dump(123)).to eq '123'
     end
 
     it 'passes options to the adapter' do
@@ -120,7 +120,7 @@ shared_examples_for "an adapter" do |adapter|
 
     it 'stringifys symbol keys when encoding' do
       dumped_json = MultiJson.dump(:a => 1, :b => {:c => 2})
-      expect(MultiJson.load(dumped_json)).to eq({"a" => 1, "b" => {"c" => 2}})
+      expect(MultiJson.load(dumped_json)).to eq({'a' => 1, 'b' => {'c' => 2}})
     end
 
     it 'properly loads valid JSON in StringIOs' do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -31,3 +31,15 @@ class MockDecoder
     '{"abc":"def"}'
   end
 end
+
+module MockModuleDecoder
+  extend self
+
+  def load(string, options={})
+    {'abc' => 'def'}
+  end
+
+  def dump(string)
+    '{"abc":"def"}'
+  end
+end

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -4,9 +4,8 @@ require 'stringio'
 
 describe 'MultiJson' do
   context 'adapters' do
-    before do
-      MultiJson.use nil
-    end
+    before{ MultiJson.use nil }
+
     context 'when no other json implementations are available' do
       before do
         @old_map = MultiJson::REQUIREMENT_MAP
@@ -72,18 +71,23 @@ describe 'MultiJson' do
       expect(MultiJson.adapter.name).to eq 'MockDecoder'
     end
 
-    context "using one-shot parser" do
-      before(:each) do
+    it 'is settable via a module' do
+      MultiJson.use MockModuleDecoder
+      expect(MultiJson.adapter.name).to eq 'MockModuleDecoder'
+    end
+
+    context 'using one-shot parser' do
+      before do
         require 'multi_json/adapters/json_pure'
         MultiJson::Adapters::JsonPure.should_receive(:dump).exactly(1).times.and_return('dump_something')
         MultiJson::Adapters::JsonPure.should_receive(:load).exactly(1).times.and_return('load_something')
       end
 
-      it "should use the defined parser just for the call" do
+      it 'should use the defined parser just for the call' do
         MultiJson.use :json_gem
         expect(MultiJson.dump('', :adapter => :json_pure)).to eq 'dump_something'
         expect(MultiJson.load('', :adapter => :json_pure)).to eq 'load_something'
-        expect(MultiJson.adapter.name).to eq "MultiJson::Adapters::JsonGem"
+        expect(MultiJson.adapter.name).to eq 'MultiJson::Adapters::JsonGem'
       end
     end
   end
@@ -112,7 +116,7 @@ describe 'MultiJson' do
     next if adapter == 'nsjsonserialization' && !macruby?
     next if jruby? && (adapter == 'oj' || adapter == 'yajl')
     context adapter do
-      it_behaves_like "an adapter", adapter
+      it_behaves_like 'an adapter', adapter
     end
   end
 end


### PR DESCRIPTION
The issue was that `@adapter` variable was set to `nil` and MultiJson skipped setting `default_adapter`.
