### PR TITLE
Do not pick JSON gem version < 1.7.7 as a default

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -30,7 +30,15 @@ module MultiJson
   def default_adapter
     return :oj if defined?(::Oj)
     return :yajl if defined?(::Yajl)
-    return :json_gem if defined?(::JSON)
+
+    if defined?(::JSON)
+      if ::JSON::VERSION >= '1.7.7'
+        return :json_gem
+      else
+        Kernel.warn "[WARNING] MultiJson is skipping JSON version #{::JSON::VERSION} since it has a vulnerability. Please upgrade your JSON gem."
+      end
+    end
+
     return :gson if defined?(::Gson)
 
     REQUIREMENT_MAP.each do |(library, adapter)|


### PR DESCRIPTION
Using a JSON gem prior to version 1.7.7 might lead to a potential DoS attack as mentioned in [CVE-2013-0269]. See [Ruby on Rails Security thread](http://goo.gl/gCWLe) for more detail.
