### PR TITLE
Global options have priority over adapter options and defaults

### DIFF
--- a/lib/multi_json/adapter.rb
+++ b/lib/multi_json/adapter.rb
@@ -35,7 +35,7 @@ module MultiJson
 
       def collect_options(method, overrides, args)
         global, local = *[MultiJson, self].map{ |r| r.send(method, *args) }
-        global.merge(local).merge(overrides)
+        local.merge(global).merge(overrides)
       end
 
     end

--- a/spec/adapter_shared_example.rb
+++ b/spec/adapter_shared_example.rb
@@ -36,9 +36,9 @@ shared_examples_for 'an adapter' do |adapter|
         MultiJson.adapter.dump_options = {:foo => 'bar'}
       end
 
-      it 'overrides global options with adapter-specific' do
-        MultiJson.dump_options = {:foo => 'foo'}
-        MultiJson.adapter.dump_options = {:foo => 'bar'}
+      it 'adapter-specific are overridden by global options' do
+        MultiJson.adapter.dump_options = {:foo => 'foo'}
+        MultiJson.dump_options = {:foo => 'bar'}
       end
     end
 
@@ -144,9 +144,9 @@ shared_examples_for 'an adapter' do |adapter|
         MultiJson.adapter.load_options = {:foo => 'bar'}
       end
 
-      it 'overrides global options with adapter-specific' do
-        MultiJson.load_options = {:foo => 'foo'}
-        MultiJson.adapter.load_options = {:foo => 'bar'}
+      it 'adapter-specific are overridden by global options' do
+        MultiJson.adapter.load_options = {:foo => 'foo'}
+        MultiJson.load_options = {:foo => 'bar'}
       end
     end
 


### PR DESCRIPTION
I thought that if we decide to bring back `quirks_mode` as a default in json_{gem,pure} adapters, the first that user will try to do to cancel it would be something like this:

``` ruby
MultiJson.load_options = MultiJson.dump_options = { quirks_mode: false }
```

And that will not work as expected because adapter-specific options (with quirks_mode enabled by default) have bigger priority.

That pull-request changes that and put global options over adapter-specific and defaults.
