### PR TITLE
MultiJson::Adapters::Oj#load ignores :symbolize_keys when it's false

### DIFF
--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -15,7 +15,7 @@ module MultiJson
       end
 
       def load(string, options={})
-        options[:symbol_keys] = true if options.delete(:symbolize_keys)
+        options[:symbol_keys] = options.delete(:symbolize_keys)
         ::Oj.load(string, options)
       end
 

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -129,6 +129,25 @@ describe 'MultiJson' do
         }.to_not change{Symbol.all_symbols.count}
       end
     end
+
+    context 'with Oj set to symbol_keys by default' do
+      before(:each) do
+        @oj_options = Oj.default_options
+        Oj.default_options = { :symbol_keys => true }
+      end
+
+      it "doesn't symbolize keys with :symbolize_keys => false" do
+        MultiJson.with_engine(:oj) do
+          example = '{"a": 1, "b": 2}'
+          expected = { 'a' => 1, 'b' => 2 }
+          expect(MultiJson.load(example, :symbolize_keys => false)).to eq expected
+        end
+      end
+
+      after(:each) do
+        Oj.default_options = @oj_options
+      end
+    end
   end
 
   describe 'default options' do


### PR DESCRIPTION
`MultiJson::Adapters::Oj#load` ignores the `:symbolize_keys` option when it's false. It matters if I set the default Oj behaviour to symbolize keys: 

``` ruby
Oj.default_options = { symbol_keys: true }
```

and then try to parse one string without symbolizing:

``` ruby
MultiJson.load('{"a":1}', symbolize_keys: false)
# => {:a=>1}
```

This pull request fixes the problem.
