### PR TITLE
Prefer JrJackson to JSON gem

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -47,8 +47,8 @@ module MultiJson
   def default_adapter
     return :oj if defined?(::Oj)
     return :yajl if defined?(::Yajl)
-    return :json_gem if defined?(::JSON)
     return :jr_jackson if defined?(::JrJackson)
+    return :json_gem if defined?(::JSON)
     return :gson if defined?(::Gson)
 
     REQUIREMENT_MAP.each do |(library, adapter)|


### PR DESCRIPTION
Hi,

Really delighted to see JrJackson support in MultiJson, thanks to @guyboertje, @rwz and @sferik for all their hard work!

This pull request addresses the fact that I feel that JrJackson should be preferred to the JSON gem if it present, due to it being close to an order of magnitude more performant! Currently MultiJson will pluck out JSON as the backend in a rails install, even if JrJackson is in the Gemfile.

This change causes the opposite behaviour, delegating to the far more performant solution first, whereas all specs are still green.

Hope that people agree that this is a good idea, thanks for an awesome project!

John
