### PR TITLE
Warn if stdlib json is used.

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -87,7 +87,9 @@ module MultiJson
   # * <tt>:gson</tt> (JRuby only)
   # * <tt>:jr_jackson</tt> (JRuby only)
   def use(new_adapter)
-    @adapter = load_adapter(new_adapter)
+    adapter = load_adapter(new_adapter)
+    adapter.activate! if adapter.respond_to?(:activate!)
+    @adapter = adapter
   end
   alias adapter= use
   alias engine= use

--- a/lib/multi_json/adapters/json_common.rb
+++ b/lib/multi_json/adapters/json_common.rb
@@ -5,6 +5,16 @@ module MultiJson
     class JsonCommon < Adapter
       defaults :load, :create_additions => false, :quirks_mode => true
 
+      GEM_VERSION = '1.7.7'
+
+      def self.activate!
+        if JSON::VERSION < GEM_VERSION
+          Kernel.warn "You are using an old or stdlib version of #{gem_name} gem\n" +
+            "Please upgrade to the recent version by adding this to your Gemfile:\n\n" +
+            "  gem '#{gem_name}', '~> #{GEM_VERSION}'\n"
+        end
+      end
+
       def load(string, options={})
         string = string.read if string.respond_to?(:read)
 

--- a/lib/multi_json/adapters/json_gem.rb
+++ b/lib/multi_json/adapters/json_gem.rb
@@ -6,6 +6,10 @@ module MultiJson
     # Use the JSON gem to dump/load.
     class JsonGem < JsonCommon
       ParseError = ::JSON::ParserError
+
+      def self.gem_name
+        'json'
+      end
     end
   end
 end

--- a/lib/multi_json/adapters/json_pure.rb
+++ b/lib/multi_json/adapters/json_pure.rb
@@ -6,6 +6,10 @@ module MultiJson
     # Use JSON pure to dump/load.
     class JsonPure < JsonCommon
       ParseError = ::JSON::ParserError
+
+      def self.gem_name
+        'json_pure'
+      end
     end
   end
 end

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -50,6 +50,25 @@ describe 'MultiJson' do
       end
     end
 
+    context 'with stdlib version' do
+      around do |example|
+        version = JSON::VERSION
+        silence_warnings{ JSON::VERSION = '1.5.5' }
+        example.call
+        silence_warnings{ JSON::VERSION = version }
+      end
+
+      it 'should warn about json' do
+        Kernel.should_receive(:warn).with(/'json', '~> 1.7.7'/)
+        MultiJson.use :json_gem
+      end
+
+      it 'should warb about json/pure' do
+        Kernel.should_receive(:warn).with(/'json_pure', '~> 1.7.7'/)
+        MultiJson.use :json_pure
+      end
+    end
+
     it 'defaults to the best available gem' do
       # Clear cache variable already set by previous tests
       MultiJson.send(:remove_instance_variable, :@adapter)


### PR DESCRIPTION
MultiJson loads stdlib version of `json` gem by default. It's broken in many ways, doesn't support some of the options we pass there and segfaults on nil input (see https://github.com/flori/json/issues/165).

I think MultiJson should check the version of `json` gem loaded and complain loudly if the version is not the latest one.

What do you think, @sferik?
