### PR TITLE
Fixed warning '*' interpreted as argument prefix

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -31,7 +31,7 @@ module MultiJson
   %w(load_options= dump_options=).each do |method|
     define_method method do |*args|
       use current_adapter
-      super *args
+      super(*args)
     end
   end
 


### PR DESCRIPTION
- ruby -w lib/multi_json.rb
- lib/multi_json.rb:34: warning: '*' interpreted as argument prefix
- Fixed this warning by wrapping *args by parenthesis
- This warning was found by me here https://travis-ci.org/rails/rails/jobs/7572922#L574
