### PR TITLE
Reorder JrJackson before json_gem

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -42,9 +42,9 @@ module MultiJson
   REQUIREMENT_MAP = [
     ['oj',           :oj],
     ['yajl',         :yajl],
+    ['jrjackson',    :jr_jackson],
     ['json/ext',     :json_gem],
     ['gson',         :gson],
-    ['jrjackson',    :jr_jackson],
     ['json/pure',    :json_pure]
   ]
 
@@ -55,9 +55,9 @@ module MultiJson
   def default_adapter
     return :oj if defined?(::Oj)
     return :yajl if defined?(::Yajl)
+    return :jr_jackson if defined?(::JrJackson)
     return :json_gem if defined?(::JSON)
     return :gson if defined?(::Gson)
-    return :jr_jackson if defined?(::JrJackson)
 
     REQUIREMENT_MAP.each do |library, adapter|
       begin

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -77,7 +77,7 @@ describe 'MultiJson' do
       unless jruby?
         expect(MultiJson.adapter).to eq MultiJson::Adapters::Oj
       else
-        expect(MultiJson.adapter).to eq MultiJson::Adapters::JsonGem
+        expect(MultiJson.adapter).to eq MultiJson::Adapters::JrJackson
       end
     end
 


### PR DESCRIPTION
There was a pull-req for preferring JrJackson over JSON here https://github.com/intridea/multi_json/commit/af8bd9799a66855f04b3aff1c488485950cec7bf, but subsequently it was reverted with this commit https://github.com/intridea/multi_json/commit/d441ec6673d7660693cbcf79316a79057a6d2a3b

This commit changes both the require order and REQUIREMENT_MAP.
