### PR TITLE
Prevent warning for uninitialized `@cached_options`

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -7,7 +7,7 @@ module MultiJson
 
   class << self
     def cached_options
-      @cached_options || reset_cached_options!
+      @cached_options ||= reset_cached_options!
     end
 
     def reset_cached_options!


### PR DESCRIPTION
The current implementation is generating a warning because `@cached_options` hasn't been initialized when it's first called. 

```
~/.gem/ruby/1.9.3/gems/multi_json-1.7.7/lib/multi_json.rb:10: warning: instance variable @cached_options not initialized
```

Using the `||=` operator prevents this warning, even though it seems like its doing the assignment twice. Not sure if there's a better option?
