### PR TITLE
"when freedom patches fight, nobody wins" -@jeremy

### DIFF
--- a/lib/multi_json/adapters/json_common.rb
+++ b/lib/multi_json/adapters/json_common.rb
@@ -18,7 +18,8 @@ module MultiJson
 
       def dump(object, options={})
         options.merge!(::JSON::PRETTY_STATE_PROTOTYPE.to_h) if options.delete(:pretty)
-        object.to_json(options)
+        options.merge!(:quirks_mode => true)
+        ::JSON.generate(object, options)
       end
     end
   end

--- a/spec/shared/json_common_adapter.rb
+++ b/spec/shared/json_common_adapter.rb
@@ -7,7 +7,7 @@ shared_examples_for 'JSON-like adapter' do |adapter|
     describe 'with :pretty option set to true' do
       it 'passes default pretty options' do
         object = 'foo'
-        expect(object).to receive(:to_json).with(JSON::PRETTY_STATE_PROTOTYPE.to_h)
+        expect(::JSON).to receive(:generate).with(object, JSON::PRETTY_STATE_PROTOTYPE.to_h.merge(:quirks_mode => true))
         MultiJson.dump(object, :pretty => true)
       end
     end
@@ -15,7 +15,7 @@ shared_examples_for 'JSON-like adapter' do |adapter|
     describe 'with :indent option' do
       it 'passes it on dump' do
         object = 'foo'
-        expect(object).to receive(:to_json).with(:indent => "\t")
+        expect(::JSON).to receive(:generate).with(object, {:indent => "\t", :quirks_mode => true})
         MultiJson.dump(object, :indent => "\t")
       end
     end


### PR DESCRIPTION
Use `JSON.generate` instead of `Object#to_json`

The reasoning behind this is that `Object#to_json` is part of the [freedom]((https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/to_json.rb#L7-L19) [patching](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/json/encoding.rb#L305-L312) wars with `ActiveSupport`. This means that in Rails out of the box for Ruby 1.9+ (since json is part of stdlib), the asset pipeline will use
the pure ruby `#to_json` method provided by `ActiveSupport`. This results in ~40% performance decrease.
