### PR TITLE
Downcase adapter string name for OS compatibility.

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -151,7 +151,7 @@ module MultiJson
 
   def load_adapter_from_string_name(name)
     name = ALIASES.fetch(name, name)
-    require "multi_json/adapters/#{name}"
+    require "multi_json/adapters/#{name.downcase}"
     klass_name = name.to_s.split('_').map(&:capitalize) * ''
     MultiJson::Adapters.const_get(klass_name)
   end


### PR DESCRIPTION
We had problems deploying to Ubuntu because I had used `MultiJson.use 'Oj'`. It worked on my OSX machine, but not on the Ubuntu machine because of how different OSes handle case-sensitivity. (I think my coworker had problems on linux as well) We changed our code to use a downcased version of the adapter, but this might help ease some pain in the future.
