### PR TITLE
Let the original LoadError exception surface

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -104,8 +104,8 @@ module MultiJson
     else
       raise ::LoadError
     end
-  rescue ::LoadError
-    raise ArgumentError, 'Did not recognize your adapter specification.'
+  rescue ::LoadError => e
+    raise ArgumentError, "Did not recognize your adapter specification (#{e.message})."
   end
 
   # Decode a JSON string into Ruby.


### PR DESCRIPTION
The proposed solution is the bare minimum, (IMO) better options are:
- use a custom exception that inherits from ArgumentError catching only exceptions that are local to the method or explicitly raised in `#load_adapter_from_string_name` (using `#const_defined?`?)
- prepend/append a "helper" message to the actual exception raise
- remove the rescue completely and let the originals reach the user
### Why?

I had a badly compiled json gem and gone mad because the message was pointing me in the wrong direction. Worst than that `oauth2` was [obliterating the exception](https://github.com/intridea/oauth2/blob/master/lib/oauth2/response.rb#L53) completely.
