### PR TITLE
[Fix] Oj expects indent as a Fixnum

### DIFF
--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -17,6 +17,7 @@ module MultiJson
 
       def dump(object, options={})
         options.merge!(:indent => 2) if options[:pretty]
+        options[:indent] = options[:indent].to_i if options[:indent]
         ::Oj.dump(object, options)
       end
     end

--- a/spec/oj_adapter_spec.rb
+++ b/spec/oj_adapter_spec.rb
@@ -7,4 +7,16 @@ require 'multi_json/adapters/oj'
 
 describe MultiJson::Adapters::Oj do
   it_behaves_like 'an adapter', described_class
+
+  describe '.dump' do
+    describe '#dump_options' do
+      before{ MultiJson.use :oj }
+      before{ MultiJson.dump_options = MultiJson.adapter.dump_options = {} }
+      after{ MultiJson.dump_options = MultiJson.adapter.dump_options = {} }
+
+      it 'ensures indent is a Fixnum' do
+        expect { MultiJson.dump(42, :indent => '')}.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
When using multi_json with Oj, and also the json lib happens to be laoded, there's a case the json lib sets indent as a String (see https://github.com/ruby/ruby/blob/v2_1_0/ext/json/lib/json/common.rb), making Oj crash with ArgumentError: :indent must be a Fixnum.
