### PR TITLE
Deal with nil

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -114,6 +114,8 @@ module MultiJson
   # <tt>:symbolize_keys</tt> :: If true, will use symbols instead of strings for the keys.
   # <tt>:adapter</tt> :: If set, the selected adapter will be used for this call.
   def load(string, options={})
+    return nil unless string
+
     adapter = current_adapter(options)
     begin
       adapter.load(string, options)
@@ -133,6 +135,8 @@ module MultiJson
 
   # Encodes a Ruby object as JSON.
   def dump(object, options={})
+    return nil unless object
+
     current_adapter(options).dump(object, options)
   end
   alias encode dump

--- a/spec/shared/adapter.rb
+++ b/spec/shared/adapter.rb
@@ -112,6 +112,10 @@ shared_examples_for 'an adapter' do |adapter|
     it 'allows to dump JSON with UTF-8 characters' do
       expect(MultiJson.dump('color' => 'żółć')).to eq('{"color":"żółć"}')
     end
+
+    it 'dumps nil when nil is provided' do
+      expect(MultiJson.dump(nil)).to eq(nil)
+    end
   end
 
   describe '.load' do
@@ -162,8 +166,12 @@ shared_examples_for 'an adapter' do |adapter|
       expect(MultiJson.load('{"abc":"def"}')).to eq('abc' => 'def')
     end
 
-    it 'raises MultiJson::ParseError on blank input or invalid input' do
-      [nil, '{"abc"}', ' ', "\t\t\t", "\n", "\x82\xAC\xEF"].each do |input|
+    it 'returns nil on nil input' do
+      expect(MultiJson.load(nil)).to eq(nil)
+    end
+
+    it 'returns MultiJson::ParseError on blank input or invalid input' do
+      ['{"abc"}', ' ', "\t\t\t", "\n", "\x82\xAC\xEF"].each do |input|
         if input == "\x82\xAC\xEF"
           pending 'GSON bug: https://github.com/avsej/gson.rb/issues/3' if adapter.name =~ /Gson/
         end


### PR DESCRIPTION
When working with serializable attributes in `rails`, I noticed a small inconsistency between ruby's `JSON` and `MultiJson` implementation - the way it deals with `nil`.

On `rails`, I'm able to use the `JSON` object as a replacement to its built-in `YAMLColumn` the following way:

``` ruby
class Model < ActiveRecord::Base
  serialize :data, JSON
end
```

This happens because `serialize` expects an object that provides the `load` and `dump` methods. Although `MultiJson` complies with that, it throws `MultiJson::ParseError` on `nil` values, which is inconsistent with the default `JSON` implementation. Same happens when dumping.

It might look coupled to rails, but dealing with nil values (and returning `nil` as well) looks totally fine to me.
