### PR TITLE
Update README To Show Conversion Result of Integer And Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ fastest available JSON coder. Here's how to use it:
 require 'multi_json'
 
 MultiJson.load('{"abc":"def"}') #=> {"abc" => "def"}
+MultiJson.load('{"abc":["def", "ghi"]}') #=> {"abc" => ["def", "ghi"]}
 MultiJson.load('{"abc":123}') #=> {"abc" => 123}
 MultiJson.load('{"abc":"def"}', :symbolize_keys => true) #=> {:abc => "def"}
 MultiJson.dump({:abc => 'def'}) # convert Ruby back to JSON {"abc" => "def"}
+MultiJson.dump({:abc => ['def', 'ghi']}) # convert Ruby back to JSON {"abc" => ["def", "ghi"]}
 MultiJson.dump({:abc => 123}) # convert Ruby back to JSON {"abc" => 123}
 MultiJson.dump({:abc => 'def'}, :pretty => true) # encoded in a pretty form (if supported by the coder)
 ```


### PR DESCRIPTION
FWIW, I updated the examples in README to show the conversion result when `MultiJson.load` and `MultiJson.dump` are called with arguments containing integer and array values.
