### PR TITLE
Pass through dump options to jrjackson

### DIFF
--- a/lib/multi_json/adapters/jr_jackson.rb
+++ b/lib/multi_json/adapters/jr_jackson.rb
@@ -12,7 +12,7 @@ module MultiJson
       end
 
       def dump(object, options={}) #:nodoc:
-        ::JrJackson::Json.dump(object)
+        ::JrJackson::Json.dump(object, options)
       end
     end
   end


### PR DESCRIPTION
Necessary if you want to set `date_format`, ie:

    MultiJson.dump_options = {date_format: "yyyy-MM-dd'T'HH:mm:ss'Z'"}