### PR TITLE
Add Ruby 2.2.0 to Ruby versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ implementations:
 * Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1.1
+* Ruby 2.2.0
 * [JRuby][]
 * [Rubinius][]
 * [MacRuby][] (not tested on Travis CI)


### PR DESCRIPTION
Extremely minor, I took a look at multi_json the other day and noticed Ruby 2.2.0 was missing from the supported versions list in the README, but is being tested against and has passing tests, this just adds it to that list. 