### PR TITLE
Cache options generated in MultiJson::Adapter

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -141,6 +141,7 @@ module MultiJson
   def with_adapter(new_adapter)
     old_adapter = adapter
     self.adapter = new_adapter
+    self.adapter.clear_cached_options
     yield
   ensure
     self.adapter = old_adapter

--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -11,7 +11,7 @@ module MultiJson
       ParseError = defined?(::Oj::ParseError) ? ::Oj::ParseError : SyntaxError
 
       def load(string, options = {})
-        options[:symbol_keys] = options.delete(:symbolize_keys)
+        options[:symbol_keys] = options[:symbolize_keys]
         ::Oj.load(string, options)
       end
 

--- a/lib/multi_json/options.rb
+++ b/lib/multi_json/options.rb
@@ -2,10 +2,12 @@ module MultiJson
   module Options
     def load_options=(options)
       @load_options = options
+      MultiJson::Adapter.clear_cached_options
     end
 
     def dump_options=(options)
       @dump_options = options
+      MultiJson::Adapter.clear_cached_options
     end
 
     def load_options(*args)


### PR DESCRIPTION
Both MultiJson::Adapter.dump and .load accept an options parameter
which had been processed on every call to before being passed through
to the underlying adapater. However, the options rarely change and
so much of this work was redundant. This changes the class to
cache the processed options, this saves a small amount of work per
call to .dump or .load.

I compared multi_json-1.11.3 with and without these changes with the following (and the Oj adapter):

```ruby
# x.rb
require 'oj'
require 'multi_json'

(10 * 1000 * 1000).times do
  j = MultiJson.dump({a: 1, b: 2, c: 3})
  MultiJson.load(j)
end
```

Vinillia 1.11.3:

```bash
$ time ruby x.rb

real	2m7.851s
user	2m0.456s
sys	0m0.092s
```

1.11.3 w/these changes:

```bash
$ time ruby x.rb

real	1m43.612s
user	1m39.100s
sys	0m0.064s
```

Admittedly the above is not particularly rigorous but I believe it illustrates that there's at least potential for a performance boost here. 
