### PR TITLE
Check if read IO object value is `blank?`

### DIFF
--- a/lib/multi_json/adapter.rb
+++ b/lib/multi_json/adapter.rb
@@ -16,8 +16,8 @@ module MultiJson
       end
 
       def load(string, options = {})
-        fail self::ParseError if blank?(string)
         string = string.read if string.respond_to?(:read)
+        fail self::ParseError if blank?(string)
         instance.load(string, cached_load_options(options))
       end
 

--- a/spec/shared/adapter.rb
+++ b/spec/shared/adapter.rb
@@ -170,7 +170,7 @@ shared_examples_for 'an adapter' do |adapter|
     end
 
     it 'raises MultiJson::ParseError on blank input or invalid input' do
-      [nil, '{"abc"}', ' ', "\t\t\t", "\n", "\x82\xAC\xEF"].each do |input|
+      [nil, '{"abc"}', ' ', "\t\t\t", "\n", "\x82\xAC\xEF", StringIO.new('')].each do |input|
         if input == "\x82\xAC\xEF"
           pending 'GSON bug: https://github.com/avsej/gson.rb/issues/3' if adapter.name =~ /Gson/
         end


### PR DESCRIPTION
Reading from IO objects is implemented in the shared adapter, but the verification for "blankness" is not applied for values read from these objects, causing `MultiJson` to fallback to each adapter interpretation of blank/invalid.
This results in different behaviour - depending on the adapter - for the same input.

This PR tries to solve this issue, making `MultiJson` always raise `Parse Error` for `blank?`ish values read from IO objects.

Behaviour with `MultiJson 1.12.1`:
```
[1] pry(main)> empty_string_io = StringIO.new('')
=> #<StringIO:0x007fe4933b8420>
[2] pry(main)> MultiJson.use :json_gem
=> MultiJson::Adapters::JsonGem
[3] pry(main)> MultiJson.load(empty_string_io)
MultiJson::ParseError: 795: unexpected token at ''
from /(...)/versions/2.2.3/lib/ruby/gems/2.2.0/gems/json-1.8.3/lib/json/common.rb:155:in `parse'
[4] pry(main)> MultiJson.use :oj
=> MultiJson::Adapters::Oj
[5] pry(main)> MultiJson.load(empty_string_io)
=> nil
```

Behaviour with changes:
```
[1] pry(main)> empty_string_io = StringIO.new('')
=> #<StringIO:0x007faa2c3b9150>
[2] pry(main)> MultiJson.use :json_gem
=> MultiJson::Adapters::JsonGem
[3] pry(main)> MultiJson.load(empty_string_io)
MultiJson::ParseError: JSON::ParserError
from /(...)/multi_json/lib/multi_json/adapter.rb:20:in `load'
[4] pry(main)> MultiJson.use :oj
=> MultiJson::Adapters::Oj
[5] pry(main)> MultiJson.load(empty_string_io)
MultiJson::ParseError: Oj::ParseError
from /(...)/multi_json/lib/multi_json/adapter.rb:20:in `load'
```