### PR TITLE
Options in Oj

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ platforms :jruby do
 end
 
 platforms :mingw, :mswin, :ruby do
-  gem 'oj', '~> 2.18', :require => nil
+  gem 'oj', '~> 3.0', :require => nil
   gem 'yajl-ruby', '~> 1.3', :require => nil
 end
 

--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -5,8 +5,8 @@ module MultiJson
   module Adapters
     # Use the Oj library to dump/load.
     class Oj < Adapter
-      defaults :load, :mode => :strict, :symbolize_keys => false
-      defaults :dump, :mode => :compat, :time_format => :ruby, :use_to_json => true
+      defaults :load, :mode => :json, :symbolize_keys => false
+      defaults :dump, :mode => :json, :time_format => :ruby, :use_to_json => true
 
       ParseError = defined?(::Oj::ParseError) ? ::Oj::ParseError : SyntaxError
 


### PR DESCRIPTION
WIP. Need to decide what to do with new Oj gem.

New Oj has json compatibility mode e.g. it is identical to original JSON gem. Which should be used here, buut in this mode Oj only accept options valid for JSON, nothing else. So this can be brake change for developer who used some special options for Oj.

PS Do we need compatibility with version 2.x?

Related https://github.com/ohler55/oj/issues/376 cc @ohler55