### PR TITLE
Add ruby 2.5.0 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - 2.5.0
   - jruby-head
   - rbx-2
   - ruby-head

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ implementations:
 * Ruby 2.2.4
 * Ruby 2.3.1
 * Ruby 2.4.0
+* Ruby 2.5.0
 * [JRuby][]
 * [Rubinius][]
 * [MacRuby][] (not tested on Travis CI)


### PR DESCRIPTION
I ran it locally with ruby 2.5.0 and it passed