### PR TITLE
Add rescue for JSON::ParserError

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -122,6 +122,8 @@ module MultiJson
       adapter.load(string, options)
     rescue adapter::ParseError => exception
       raise ParseError.build(exception, string)
+    rescue JSON::ParserError => exception
+      raise ParseError.build(exception, string)
     end
   end
   alias_method :decode, :load


### PR DESCRIPTION
The Oj parser v3.3.7+ will throw an Oj::ParseError and
(when mimicking json) a JSON::ParserError.

MultiJSON assumes that any JSON parser will just throw
one specific type of exception, but it seems fair to
also rescue any JSON::ParserError thrown while parsing.

Solves: https://github.com/ruby-json-schema/json-schema/issues/399