### PR TITLE
Fix Ruby 2.7 warning

### DIFF
--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -7,9 +7,9 @@ module MultiJson
       @load_cache = {}
     end
 
-    def fetch(type, key)
+    def fetch(type, key, &block)
       cache = instance_variable_get("@#{type}_cache")
-      cache.key?(key) ? cache[key] : write(cache, key, &Proc.new)
+      cache.key?(key) ? cache[key] : write(cache, key, &block)
     end
 
     private


### PR DESCRIPTION
I understand that Ruby versions after 2.5 are not currently supported, but as far as I can test -- the CI will tell -- this should not break anything with older Rubies, and multi_json _is_ used by projects that do support newer versions, so we can see `warning: tried to create a Proc object without giving a block` in, for example, [Rails CI](https://travis-ci.org/rails/rails/jobs/490316768#L4227).

