### PR TITLE
Oj 2 and 3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ platforms :jruby do
 end
 
 platforms :mingw, :mswin, :ruby do
-  gem 'oj', '~> 2.18', :require => nil
+  gem 'oj', '>= 2.18', '< 4.0', :require => nil
   gem 'yajl-ruby', '~> 1.3', :require => nil
 end
 

--- a/lib/multi_json/adapters/oj.rb
+++ b/lib/multi_json/adapters/oj.rb
@@ -34,10 +34,29 @@ module MultiJson
         ::Oj.load(string, options)
       end
 
-      def dump(object, options = {})
-        options.merge!(:indent => 2) if options[:pretty]
-        options[:indent] = options[:indent].to_i if options[:indent]
-        ::Oj.dump(object, options)
+      case ::Oj::VERSION
+      when /\A2\./
+        def dump(object, options = {})
+          options.merge!(:indent => 2) if options[:pretty]
+          options[:indent] = options[:indent].to_i if options[:indent]
+          ::Oj.dump(object, options)
+        end
+      when /\A3\./
+        PRETTY_STATE_PROTOTYPE = {
+          :indent                => "  ",
+          :space                 => " ",
+          :space_before          => "",
+          :object_nl             => "\n",
+          :array_nl              => "\n",
+          :ascii_only            => false,
+        }
+
+        def dump(object, options = {})
+          options.merge!(PRETTY_STATE_PROTOTYPE.dup) if options.delete(:pretty)
+          ::Oj.dump(object, options)
+        end
+      else
+        fail "Unsupported Oj version: #{::Oj::VERSION}"
       end
     end
   end


### PR DESCRIPTION
By using dynamic definition, we can support both versions with only
tiny cost at start-up.  Oj3 has made its option hash more like the
JSON gem's, but duplicate "by hand" the "pretty" option hash as it's
small and slow-changing enough, and to avoid surprises with new Ruby
versions.

Closes #181 