### PR TITLE
This fixes warnings on Ruby 2.7

### DIFF
--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -7,9 +7,9 @@ module MultiJson
       @load_cache = {}
     end
 
-    def fetch(type, key)
+    def fetch(type, key, &block)
       cache = instance_variable_get("@#{type}_cache")
-      cache.key?(key) ? cache[key] : write(cache, key, &Proc.new)
+      cache.key?(key) ? cache[key] : write(cache, key, &block)
     end
 
     private


### PR DESCRIPTION
Ruby 2.7 issues warnings for `Proc.new` without a block:

```
warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

This patch converts the `Proc.new` calls in to `&block`