### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/multi_json.gemspec
+++ b/multi_json.gemspec
@@ -7,11 +7,19 @@ Gem::Specification.new do |spec|
   spec.summary       = "A common interface to multiple JSON libraries."
   spec.description   = "A common interface to multiple JSON libraries, including Oj, Yajl, the JSON gem (with C-extensions), the pure-Ruby JSON gem, NSJSONSerialization, gson.rb, JrJackson, and OkJson."
   spec.files         = Dir["*.md", "lib/**/*"]
-  spec.homepage      = "http://github.com/intridea/multi_json"
+  spec.homepage      = "https://github.com/intridea/multi_json"
   spec.license       = "MIT"
   spec.name          = "multi_json"
   spec.require_path  = "lib"
   spec.version       = MultiJson::Version
+
+  spec.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/intridea/multi_json/issues',
+    'changelog_uri'     => "https://github.com/intridea/multi_json/blob/v#{spec.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/multi_json/#{spec.version}",
+    'source_code_uri'   => "https://github.com/intridea/multi_json/tree/v#{spec.version}",
+    'wiki_uri'          => 'https://github.com/intridea/multi_json/wiki'
+  }
 
   spec.required_rubygems_version = ">= 1.3.5"
   spec.add_development_dependency "rake", "~> 10.5"


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `source_code_uri`, and `wiki_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/multi_json), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.