### PR TITLE
Fix detection for the json_gem adapter

### DIFF
--- a/lib/multi_json.rb
+++ b/lib/multi_json.rb
@@ -47,7 +47,7 @@ module MultiJson
     return :oj if defined?(::Oj)
     return :yajl if defined?(::Yajl)
     return :jr_jackson if defined?(::JrJackson)
-    return :json_gem if defined?(::JSON::JSON_LOADED)
+    return :json_gem if defined?(::JSON::Ext::Parser)
     return :gson if defined?(::Gson)
 
     REQUIREMENT_MAP.each do |adapter, library|

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -30,6 +30,24 @@ describe MultiJson do
     end
   end
 
+  context 'when JSON pure is already loaded' do
+    it 'default_adapter tries to require each adapter in turn and does not assume :json_gem is already loaded' do
+      require 'json/pure'
+      expect(JSON::JSON_LOADED).to be_truthy
+
+      undefine_constants :Oj, :Yajl, :Gson, :JrJackson do
+        # simulate that the json_gem is not loaded
+        ext = defined?(JSON::Ext::Parser) ? JSON::Ext.send(:remove_const, :Parser) : nil
+        begin
+          expect(MultiJson).to receive(:require)
+          MultiJson.default_adapter
+        ensure
+          JSON::Ext::Parser = ext if ext
+        end
+      end
+    end
+  end
+
   context 'caching' do
     before { MultiJson.use adapter }
     let(:adapter) { MultiJson::Adapters::JsonGem }


### PR DESCRIPTION
* JSON::JSON_LOADED is also set by json/pure and so it is not enough to detect if the JSON native extension is loaded.
* JSON::Ext is not enough either, because json_pure includes json/ext.rb.
* JSON::Ext::Parser is only defined if the native extension is loaded so that is reliable.
* Fixes https://github.com/intridea/multi_json/issues/196
* See that issue for details.

The spec fails before the fix, and passes after the fix.