### PR TITLE
Add Ruby 3.0 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,48 +2,16 @@ language: ruby
 
 matrix:
   include:
-  - rvm: 1.8
-    gemfile: gemfiles/gemfile-1-8
-    os: linux
-    dist: trusty
-    env: SKIP_ADAPTERS=yajl,gson,jr_jackson,nsjsonserialization
-  - rvm: jruby-18mode
-    gemfile: gemfiles/gemfile-1-8-jruby
-    os: linux
-    dist: trusty
-    env: SKIP_ADAPTERS=oj,yajl,nsjsonserialization
-  - rvm: 1.9
-    gemfile: gemfiles/gemfile-1-9
-    os: linux
-    dist: trusty
-    env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
-  - rvm: jruby-19mode
-    gemfile: gemfiles/gemfile-1-9-jruby
-    os: linux
-    dist: trusty
-    env: SKIP_ADAPTERS=oj,yajl,nsjsonserialization
-  - rvm: 2.0
-    gemfile: gemfiles/gemfile-2-0
-    env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
-  - rvm: 2.1
-    gemfile: gemfiles/gemfile-2-0
-    env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
-  - rvm: 2.2
-    gemfile: gemfiles/gemfile-2-0
-    env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
-  - rvm: 2.3
+  - rvm: '3.0'
     gemfile: gemfiles/gemfile-2-3
     env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
-  - rvm: 2.4
+  - rvm: '3.1'
     gemfile: gemfiles/gemfile-2-3
     env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
-  - rvm: 2.5
+  - rvm: '3.2'
     gemfile: gemfiles/gemfile-2-3
     env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
-  - rvm: 2.6
-    gemfile: gemfiles/gemfile-2-3
-    env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
-  - rvm: 2.7
+  - rvm: '3.3'
     gemfile: gemfiles/gemfile-2-3
     env: SKIP_ADAPTERS=gson,jr_jackson,nsjsonserialization
   - rvm: ruby-head

--- a/README.md
+++ b/README.md
@@ -60,15 +60,11 @@ MultiJSON falls back to [OkJson][], a simple, vendorable JSON parser.
 This library aims to support and is [tested against][travis] the following Ruby
 implementations:
 
-* Ruby 1.8
-* Ruby 1.9
-* Ruby 2.0
-* Ruby 2.1
-* Ruby 2.2
-* Ruby 2.4
-* Ruby 2.5
-* Ruby 2.6
-* Ruby 2.7
+
+* Ruby 3.0
+* Ruby 3.1
+* Ruby 3.2
+* Ruby 3.3
 * [JRuby][]
 
 If something doesn't work in one of these implementations, it's a bug.


### PR DESCRIPTION
I've added some support for ruby 3.0 in travis configuration. The quotes are just here in case you choose to move to GitHub actions, I can get rid of it if need be.

More on Travis VS GitHub actions. Support for open source from travis has gone missing (https://news.ycombinator.com/item?id=25155203), I can make a next PR moving from travis to github actions if you want 🙂. Done that for most of my repos now, it is easy and support matrix as well (and support windows if you ever want to add tests for it)

If I am to make that PR, may I remove tests for unsupported ruby versions (1.8 up to 2.4, https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/)?

Thanks for the great gem!