### PR TITLE
Reset options cache if cache doesn't exist yet

### DIFF
--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -9,7 +9,7 @@ module MultiJson
 
     def fetch(type, key, &block)
       cache = instance_variable_get("@#{type}_cache")
-      cache.key?(key) ? cache[key] : write(cache, key, &block)
+      (cache && cache.key?(key)) ? cache[key] : write(cache, key, &block)
     end
 
     private

--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -22,12 +22,9 @@ module MultiJson
     MAX_CACHE_SIZE = 1000
 
     def write(cache, key)
-      if cache
-        cache.clear if cache.length >= MAX_CACHE_SIZE
-        cache[key] = yield
-      else
-        reset
-      end
+      reset unless cache
+      cache.clear if cache.length >= MAX_CACHE_SIZE
+      cache[key] = yield
     end
   end
 end

--- a/lib/multi_json/options_cache.rb
+++ b/lib/multi_json/options_cache.rb
@@ -22,8 +22,12 @@ module MultiJson
     MAX_CACHE_SIZE = 1000
 
     def write(cache, key)
-      cache.clear if cache.length >= MAX_CACHE_SIZE
-      cache[key] = yield
+      if cache
+        cache.clear if cache.length >= MAX_CACHE_SIZE
+        cache[key] = yield
+      else
+        reset
+      end
     end
   end
 end


### PR DESCRIPTION
At the moment you get an error the first time you try to specify an adapter. This PR modifies the OptionsCache module so that it checks to make sure the cache exists before trying to access it, and resets if it doesn't exist yet.

Addresses https://github.com/intridea/multi_json/issues/208