### PR TITLE
Skip jr_jackson test unless jruby

### DIFF
--- a/spec/jr_jackson_adapter_spec.rb
+++ b/spec/jr_jackson_adapter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-return if skip_adapter?('jr_jackson')
+return if !jruby? || skip_adapter?('jr_jackson')
 
 require 'shared/adapter'
 require 'multi_json/adapters/jr_jackson'

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -75,7 +75,7 @@ describe MultiJson do
     if jruby? && !skip_adapter?('jr_jackson')
       expect(MultiJson.adapter.to_s).to eq('MultiJson::Adapters::JrJackson')
     elsif jruby?
-      expect(MultiJson.adapter.to_s).to eq('MultiJson::Adapters::JsonGem')      
+      expect(MultiJson.adapter.to_s).to eq('MultiJson::Adapters::JsonGem')
     else
       expect(MultiJson.adapter.to_s).to eq('MultiJson::Adapters::Oj')
     end
@@ -175,7 +175,7 @@ describe MultiJson do
   it_behaves_like 'has options', MultiJson
 
   describe 'aliases' do
-    unless skip_adapter?('jr_jackson')
+    if jruby? && !skip_adapter?('jr_jackson')
       describe 'jrjackson' do
         after { expect(MultiJson.adapter).to eq(MultiJson::Adapters::JrJackson) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ end
 
 def skip_adapter?(adapter_name)
   @skip||=
-    ENV.fetch('SKIP_ADAPTERS', '')
+    ENV.fetch('SKIP_ADAPTERS', 'nsjsonserialization')
     .split(',')
     .then do |skip|
       if jruby?


### PR DESCRIPTION
I noticed that if I ran `rake` locally the jr_jackson specs would fail because I wasn't running JRuby. This PR just modifies it to skip the specs unless it's JRuby, which is already done elsewhere within the specs.

There's also a whitespace trim.

Edit: I'm also skipping nsjsonserialization by default in the spec helper because, as per your own comments, it's a legacy parser of some sort. I am not even sure what it's for, as I could not find an "ok_json" gem.