### PR TITLE
Add Windows to platforms for oj and yajl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,34 @@
-name: Test
+name: Ruby
 
 on:
   push:
     branches: [main, master] # TODO: rename and get rid of 'master'
-  # Triggers the workflow on pull request events.
+    paths-ignore:
+      - '**/*.md'
   pull_request:
-    types: [opened, reopened, synchronize]
-  # Allows you to run this workflow manually from the Actions tab
+    branches: [main, master] # TODO: rename and get rid of 'master'
+    paths-ignore:
+      - '**/*.md'
   workflow_dispatch:
-
-# This allows a subsequently queued workflow run to interrupt previous runs.
-concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
-  cancel-in-progress: true
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby:
-          # https://www.ruby-lang.org/en/downloads/branches/
-          - "ruby-3.0"
-          - "ruby-3.1"
-          - "ruby-3.2"
-          - "ruby-3.3"
-          - "ruby-head"
-          # https://github.com/jruby/jruby/discussions/7915
-          - "jruby-9.4"
-          - "jruby-head"
-    name: "Test (Ruby ${{ matrix.ruby }})"
-    env:
-      SKIP_ADAPTERS: jr_jackson,nsjsonserialization,json_pure
+        ruby-version: ['3.0', '3.1', '3.2', 'jruby']
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - run: bundle install
-      - run: bundle exec rake
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: false # Do not bundle install yet, need recent versions for Windows
+    - name: Run tests
+      run: |
+        gem install bundler
+        bundle install
+        bundle exec rake
+

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "standard", ">= 1.35.1"
 
 gem "gson", ">= 0.6", platforms: [:jruby], require: false
 gem "jrjackson", ">= 0.4.18", platforms: [:jruby], require: false
-gem "oj", "~> 3.0", platforms: [:ruby], require: false
-gem "yajl-ruby", "~> 1.3", platforms: [:ruby], require: false
+gem "oj", "~> 3.0", platforms: [:ruby, :windows], require: false
+gem "yajl-ruby", "~> 1.3", platforms: [:ruby, :windows], require: false
 
 gemspec


### PR DESCRIPTION
I forgot that "ruby" doesn't include MS Windows in the Gemfile platforms. Since it's reasonable to expect that a compiler is available on Windows these days, this should be added.

I was able to build and test this on my Windows 7 VM successfully.

In order to verify this worked I had to update the github action config, and did some refactoring while I was here.