### PR TITLE
Stop referencing `JSON::PRETTY_STATE_PROTOTYPE`

### DIFF
--- a/lib/multi_json/adapters/json_common.rb
+++ b/lib/multi_json/adapters/json_common.rb
@@ -13,7 +13,15 @@ module MultiJson
       end
 
       def dump(object, options = {})
-        options.merge!(::JSON::PRETTY_STATE_PROTOTYPE.to_h) if options.delete(:pretty)
+        if options.delete(:pretty)
+          options.merge!({
+            indent: '  ',
+            space: ' ',
+            object_nl: "\n",
+            array_nl: "\n",
+          })
+        end
+
         object.to_json(options)
       end
     end

--- a/spec/shared/adapter.rb
+++ b/spec/shared/adapter.rb
@@ -61,7 +61,6 @@ shared_examples_for "an adapter" do |adapter|
     let(:json_pure){ Kernel.const_get('MultiJson::Adapters::JsonPure') rescue nil }
 
     it "dumps time in correct format" do
-      pending "https://github.com/flori/json/issues/573" if json_pure
       time = Time.at(1_355_218_745).utc
 
       dumped_json = MultiJson.dump(time)

--- a/spec/shared/json_common_adapter.rb
+++ b/spec/shared/json_common_adapter.rb
@@ -7,7 +7,12 @@ shared_examples_for "JSON-like adapter" do |adapter|
     describe "with :pretty option set to true" do
       it "passes default pretty options" do
         object = "foo"
-        expect(object).to receive(:to_json).with(JSON::PRETTY_STATE_PROTOTYPE.to_h)
+        expect(object).to receive(:to_json).with({
+          indent: '  ',
+          space: ' ',
+          object_nl: "\n",
+          array_nl: "\n",
+        })
         MultiJson.dump(object, pretty: true)
       end
     end


### PR DESCRIPTION
Ref: https://github.com/ruby/json/issues/788

It is private API and will be removed.

By the way @sferik would you wish some help with `multi_json`? 